### PR TITLE
Fix regex: Would otherwise return more values from grep

### DIFF
--- a/check-kernel-config
+++ b/check-kernel-config
@@ -325,7 +325,7 @@ for c in $CONFIGS_EQ;do
 		egreen "$c is already set correctly."
 		continue
 	elif grep "^$lhs" "$FILE" >/dev/null;then
-		cur=$(awk -F= '{ print $2 }' <(grep "$lhs" "$FILE"))
+		cur=$(awk -F= '{ print $2 }' <(grep "^$lhs=" "$FILE"))
 		ered "$lhs is set, but to $cur not $rhs."
 		if $write ; then
 			egreen "Setting $c correctly"


### PR DESCRIPTION
This was tough thing, when a config like CONFIG_DEFAULT_SECURITY="xyz" existed, but also one with e.g. CONFIG_DEFAULT_SECURITY_SELINUX then the grep would return 2 lines.
Also awk would then return 2 lines, killing the sed script later.
