### PR TITLE
Use a different separator for sed 's' command

### DIFF
--- a/check-kernel-config
+++ b/check-kernel-config
@@ -344,7 +344,7 @@ for c in $CONFIGS_EQ;do
 		ered "$lhs is set, but to $cur not $rhs."
 		if $write ; then
 			egreen "Setting $c correctly"
-			sed -i 's,^'"$lhs"'.*,# '"$lhs"' was '"$cur"'\n'"$c"',' "$FILE"
+			sed -i 's;^'"$lhs"'.*;# '"$lhs"' was '"$cur"'\n'"$c"';' "$FILE"
 			fixes=$((fixes+1))
 		fi
 	else


### PR DESCRIPTION
The sed expression that is used to set specific config values doesn't work while trying to set the following config:  `CONFIG_ANDROID_BINDER_DEVICES="binder,hwbinder,vndbinder,anbox-binder,anbox-hwbinder,anbox-vndbinder"`
Instead, it throws the following error:
`sed: -e expression # 1, char 80: unknown option to 's'`

This is because the argument separator (comma) also appears in the expression argument itself. That causes sed to interpret the `h` in `binder,hwbinder` as an option to the `s` command.

This change makes semicolon (`;`) the separator instead of comma (`,`) to avoid the issue. If a new config value with a semicolon in it is ever added to the list in `$CONFIGS_EQ`, this will have to be changed.